### PR TITLE
Allows AMBs to require payments to emit messages.

### DIFF
--- a/src/interfaces/IIncentivizedMessageEscrow.sol
+++ b/src/interfaces/IIncentivizedMessageEscrow.sol
@@ -25,7 +25,14 @@ interface IIncentivizedMessageEscrow is IMessageEscrowStructs, IMessageEscrowErr
         IncentiveDescription calldata incentive
     ) external payable returns(uint256 gasRefund, bytes32 messageIdentifier);
 
-    function processMessage(bytes calldata messagingProtocolContext, bytes calldata message, bytes32 feeRecipitent) external;
+    function processMessage(bytes calldata messagingProtocolContext, bytes calldata message, bytes32 feeRecipitent) payable external;
 
     function setRemoteEscrowImplementation(bytes32 chainIdentifier, bytes calldata implementation) external;
+
+    /**
+     * @notice Estimates the additional cost to the messaging router to validate the message
+     * @return asset The asset the token is in. If native token, returns address(0);
+     * @return amount The number of assets to pay.
+     */
+    function estimateAdditionalCost() external view returns(address asset, uint256 amount);
 }

--- a/test/IncentivizedMessageEscrow/feature/SendMessagePayment.t.sol
+++ b/test/IncentivizedMessageEscrow/feature/SendMessagePayment.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import { TestCommon } from "../../TestCommon.t.sol";
+import "../../../src/apps/mock/IncentivizedMockEscrow.sol";
+import "../../../src/interfaces/IIncentivizedMessageEscrow.sol";
+import { IMessageEscrowEvents } from "../../../src/interfaces/IMessageEscrowEvents.sol";
+import { IMessageEscrowStructs } from "../../../src/interfaces/IMessageEscrowStructs.sol";
+import "./../../mocks/MockApplication.sol";
+import { ICrossChainReceiver } from "../../../src/interfaces/ICrossChainReceiver.sol";
+
+contract SendMessagePaymentTest is TestCommon {
+
+    uint128 constant SEND_MESSAGE_PAYMENT_COST = 10_000;
+
+    uint256 _receive;
+
+    event Message(
+        bytes32 destinationIdentifier,
+        bytes recipitent,
+        bytes message
+    );
+
+    function setUp() override public {
+        (SIGNER, PRIVATEKEY) = makeAddrAndKey("signer");
+        _REFUND_GAS_TO = makeAddr("Alice");
+        BOB = makeAddr("Bob");
+        escrow = new IncentivizedMockEscrow(_DESTINATION_IDENTIFIER, SIGNER, SEND_MESSAGE_PAYMENT_COST);
+
+        application = ICrossChainReceiver(address(new MockApplication(address(escrow))));
+
+        // Set implementations to the escrow address.
+        vm.prank(address(application));
+        escrow.setRemoteEscrowImplementation(_DESTINATION_IDENTIFIER, abi.encode(address(escrow)));
+
+        vm.prank(address(this));
+        escrow.setRemoteEscrowImplementation(_DESTINATION_IDENTIFIER, abi.encode(address(escrow)));
+
+        _MESSAGE = abi.encode(keccak256(abi.encode(1)));
+        _DESTINATION_ADDRESS_THIS = abi.encodePacked(
+            uint8(20),
+            bytes32(0),
+            bytes32(uint256(uint160(address(this))))
+        );
+        _DESTINATION_ADDRESS_APPLICATION = abi.encodePacked(
+            uint8(20),
+            bytes32(0),
+            bytes32(uint256(uint160(address(application))))
+        );
+
+        _INCENTIVE = IncentiveDescription({
+            maxGasDelivery: 1199199,
+            maxGasAck: 1188188,
+            refundGasTo: _REFUND_GAS_TO,
+            priceOfDeliveryGas: 123321,
+            priceOfAckGas: 321123,
+            targetDelta: 30 minutes
+        });
+    }
+
+    function test_estimate_cost() external {
+        (address asset, uint256 cost) = escrow.estimateAdditionalCost();
+
+        assertEq(asset, address(0));
+        assertEq(cost, SEND_MESSAGE_PAYMENT_COST);
+    }
+
+    function test_send_message_with_additional_cost() external {
+        IncentiveDescription storage incentive = _INCENTIVE;
+        (uint256 gasRefund, bytes32 messageIdentifier) = escrow.escrowMessage{value: _getTotalIncentive(_INCENTIVE) + SEND_MESSAGE_PAYMENT_COST}(
+            bytes32(uint256(0x123123) + uint256(2**255)),
+            _DESTINATION_ADDRESS_THIS,
+            _MESSAGE,
+            incentive
+        );
+
+        // Check that the message identifier points exposes the bounty.
+        IncentiveDescription memory storedIncentiveAtEscrow = escrow.bounty(messageIdentifier);
+
+        assertEq(incentive.maxGasDelivery, storedIncentiveAtEscrow.maxGasDelivery);
+        assertEq(incentive.maxGasAck, storedIncentiveAtEscrow.maxGasAck);
+        assertEq(incentive.refundGasTo, storedIncentiveAtEscrow.refundGasTo);
+        assertEq(incentive.priceOfDeliveryGas, storedIncentiveAtEscrow.priceOfDeliveryGas);
+        assertEq(incentive.priceOfAckGas, storedIncentiveAtEscrow.priceOfAckGas);
+        assertEq(incentive.targetDelta, storedIncentiveAtEscrow.targetDelta);
+    }
+
+    function test_error_send_message_without_additional_cost() external {
+        IncentiveDescription storage incentive = _INCENTIVE;
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "NotEnoughGasProvided(uint128,uint128)",
+                529440925003,
+                529440925002
+            )
+        );
+        (uint256 gasRefund, bytes32 messageIdentifier) = escrow.escrowMessage{value: _getTotalIncentive(_INCENTIVE) + SEND_MESSAGE_PAYMENT_COST - 1}(
+            bytes32(uint256(0x123123) + uint256(2**255)),
+            _DESTINATION_ADDRESS_THIS,
+            _MESSAGE,
+            incentive
+        );
+
+        // Check that the message identifier points exposes the bounty.
+        IncentiveDescription memory storedIncentiveAtEscrow = escrow.bounty(messageIdentifier);
+
+        assertNotEq(incentive.maxGasDelivery, storedIncentiveAtEscrow.maxGasDelivery);
+        assertNotEq(incentive.maxGasAck, storedIncentiveAtEscrow.maxGasAck);
+        assertNotEq(incentive.refundGasTo, storedIncentiveAtEscrow.refundGasTo);
+        assertNotEq(incentive.priceOfDeliveryGas, storedIncentiveAtEscrow.priceOfDeliveryGas);
+        assertNotEq(incentive.priceOfAckGas, storedIncentiveAtEscrow.priceOfAckGas);
+        assertNotEq(incentive.targetDelta, storedIncentiveAtEscrow.targetDelta);
+    }
+
+    function test_process_message_with_additional_payment(bytes calldata message) external {
+        (bytes32 messageIdentifier, bytes memory messageWithContext) = setupEscrowMessage(address(application), message);
+        bytes32 feeRecipitent = bytes32(uint256(uint160(address(this))));
+
+        (uint8 v, bytes32 r, bytes32 s) = signMessageForMock(messageWithContext);
+        bytes memory mockContext = abi.encode(v, r, s);
+
+        bytes memory mockAck = abi.encode(keccak256(bytes.concat(message, _DESTINATION_ADDRESS_APPLICATION)));
+
+        escrow.processMessage{value: SEND_MESSAGE_PAYMENT_COST}(
+            mockContext,
+            messageWithContext,
+            feeRecipitent
+        );
+    }
+
+    function test_process_message_without_additional_payment(bytes calldata message) external {
+        (bytes32 messageIdentifier, bytes memory messageWithContext) = setupEscrowMessage(address(application), message);
+        bytes32 feeRecipitent = bytes32(uint256(uint160(address(this))));
+
+        (uint8 v, bytes32 r, bytes32 s) = signMessageForMock(messageWithContext);
+        bytes memory mockContext = abi.encode(v, r, s);
+
+        bytes memory mockAck = abi.encode(keccak256(bytes.concat(message, _DESTINATION_ADDRESS_APPLICATION)));
+
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "NotEnoughGasProvidedForVerification()"
+            )
+        );
+        escrow.processMessage{value: SEND_MESSAGE_PAYMENT_COST - 1}(
+            mockContext,
+            messageWithContext,
+            feeRecipitent
+        );
+    }
+}

--- a/test/IncentivizedMessageEscrow/processMessage/GasSpendControl.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/GasSpendControl.sol
@@ -108,7 +108,7 @@ contract GasSpendControlTest is TestCommon {
 
         // The strange gas limit of '<gas> + 5000 - 2' here is because <gas> is how much is actually spent (read from trace) and + 5000 - 2 is some kind of refund that
         // the relayer needs to add as extra. (reentry refund)
-        escrow.processMessage{gas: 240296}(
+        escrow.processMessage{gas: 240360}(
             mockContext,
             messageWithContext,
             destinationFeeRecipitent
@@ -130,7 +130,7 @@ contract GasSpendControlTest is TestCommon {
                 )
             )
         );
-        escrow.processMessage{gas: 240296 - 1}(
+        escrow.processMessage{gas: 240360 - 1}(
             mockContext,
             messageWithContext,
             destinationFeeRecipitent

--- a/test/IncentivizedMessageEscrow/processMessage/GasSpendControl.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/GasSpendControl.sol
@@ -108,7 +108,7 @@ contract GasSpendControlTest is TestCommon {
 
         // The strange gas limit of '<gas> + 5000 - 2' here is because <gas> is how much is actually spent (read from trace) and + 5000 - 2 is some kind of refund that
         // the relayer needs to add as extra. (reentry refund)
-        escrow.processMessage{gas: 240197}(
+        escrow.processMessage{gas: 240296}(
             mockContext,
             messageWithContext,
             destinationFeeRecipitent
@@ -130,7 +130,7 @@ contract GasSpendControlTest is TestCommon {
                 )
             )
         );
-        escrow.processMessage{gas: 240197 - 1}(
+        escrow.processMessage{gas: 240296 - 1}(
             mockContext,
             messageWithContext,
             destinationFeeRecipitent

--- a/test/IncentivizedMessageEscrow/processMessage/Reentry.call.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/Reentry.call.t.sol
@@ -61,7 +61,7 @@ contract CallReentryTest is TestCommon, ICrossChainReceiver {
                 messageIdentifier,
                 _DESTINATION_ADDRESS_APPLICATION,
                 feeRecipitent,
-                uint48(0xffea),  // Gas used
+                uint48(0x1000b),  // Gas used
                 uint64(1),
                 uint8(1)
             )

--- a/test/IncentivizedMessageEscrow/processMessage/Reentry.call.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/Reentry.call.t.sol
@@ -61,7 +61,7 @@ contract CallReentryTest is TestCommon, ICrossChainReceiver {
                 messageIdentifier,
                 _DESTINATION_ADDRESS_APPLICATION,
                 feeRecipitent,
-                uint48(0xfff9),  // Gas used
+                uint48(0xffea),  // Gas used
                 uint64(1),
                 uint8(1)
             )

--- a/test/TestCommon.t.sol
+++ b/test/TestCommon.t.sol
@@ -43,7 +43,7 @@ contract TestCommon is Test, IMessageEscrowEvents, IMessageEscrowStructs {
         (SIGNER, PRIVATEKEY) = makeAddrAndKey("signer");
         _REFUND_GAS_TO = makeAddr("Alice");
         BOB = makeAddr("Bob");
-        escrow = new IncentivizedMockEscrow(_DESTINATION_IDENTIFIER, SIGNER);
+        escrow = new IncentivizedMockEscrow(_DESTINATION_IDENTIFIER, SIGNER, 0);
 
         application = ICrossChainReceiver(address(new MockApplication(address(escrow))));
 

--- a/test/TestCommon.t.sol
+++ b/test/TestCommon.t.sol
@@ -101,7 +101,8 @@ contract TestCommon is Test, IMessageEscrowEvents, IMessageEscrowStructs {
 
     function setupEscrowMessage(address fromAddress, bytes memory message) internal returns(bytes32, bytes memory) {
         vm.recordLogs();
-        (uint256 gasRefund, bytes32 messageIdentifier) = ICanEscrowMessage(fromAddress).escrowMessage{value: _getTotalIncentive(_INCENTIVE)}(
+        (address asset, uint256 cost) = escrow.estimateAdditionalCost();
+        (uint256 gasRefund, bytes32 messageIdentifier) = ICanEscrowMessage(fromAddress).escrowMessage{value: _getTotalIncentive(_INCENTIVE) + cost}(
             _DESTINATION_IDENTIFIER,
             _DESTINATION_ADDRESS_APPLICATION,
             message,
@@ -119,8 +120,9 @@ contract TestCommon is Test, IMessageEscrowEvents, IMessageEscrowStructs {
         (uint8 v, bytes32 r, bytes32 s) = signMessageForMock(message);
         bytes memory mockContext = abi.encode(v, r, s);
 
+        (address asset, uint256 cost) = escrow.estimateAdditionalCost();
         vm.recordLogs();
-        escrow.processMessage(
+        escrow.processMessage{value: cost}(
             mockContext,
             message,
             destinationFeeRecipitent


### PR DESCRIPTION
This can be facilitates as either dedicated tokens (place the transferFrom within the _sendMessage) or gas tokens (see mock implementation).

It can be implemented on both `escrow` and `delivery`. AMBs should provide an easy way to estimate the cost: Which and how many tokens are required?