### PR TITLE
feat: Add msg.sender to message identifier

### DIFF
--- a/src/IncentivizedMessageEscrow.sol
+++ b/src/IncentivizedMessageEscrow.sol
@@ -72,12 +72,16 @@ abstract contract IncentivizedMessageEscrow is IIncentivizedMessageEscrow, Bytes
         SEND_LOST_GAS_TO = sendLostGasTo;
     }
 
-    /// @notice Generates a unique message identifier for a message
-    /// @dev Should be overwritten. The identifier should:
-    ///  - Be unique over time: Use blocknumber or blockhash
-    ///  - Be unique on destination chain: Use a unique source identifier 
-    ///  - Be unique on the source chain: Use a unique destinationIdentifier
-    ///  - Depend on the message
+    /**
+     * @notice Generates a unique message identifier for a message
+     * @dev Should be overwritten. The identifier should:
+     *  - Be unique over time: Use blocknumber or blockhash
+     *  - Be unique on destination chain: Use a unique source identifier 
+     *  - Be unique on the source chain: Use a unique destinationIdentifier
+     *  - Depend on the message
+     *  - Depend on the sender such that applications can't be dosed. 
+     *  This also implies that application should make their messages user specific.
+     */
     function _getMessageIdentifier(
         bytes32 destinationIdentifier,
         bytes calldata message

--- a/src/apps/mock/IncentivizedMockEscrow.sol
+++ b/src/apps/mock/IncentivizedMockEscrow.sol
@@ -36,6 +36,7 @@ contract IncentivizedMockEscrow is IncentivizedMessageEscrow, Ownable2Step {
     ) internal override view returns(bytes32) {
         return keccak256(
             abi.encodePacked(
+                msg.sender,
                 bytes32(block.number),
                 UNIQUE_SOURCE_IDENTIFIER, 
                 destinationIdentifier,

--- a/src/apps/mock/OnRecvIncentivizedMockEscrow.sol
+++ b/src/apps/mock/OnRecvIncentivizedMockEscrow.sol
@@ -44,6 +44,7 @@ contract OnRecvIncentivizedMockEscrow is IMETimeoutExtension {
     ) internal override view returns(bytes32) {
         return keccak256(
             abi.encodePacked(
+                msg.sender,
                 bytes32(block.number),
                 UNIQUE_SOURCE_IDENTIFIER, 
                 destinationIdentifier,

--- a/src/apps/wormhole/IncentivizedWormholeEscrow.sol
+++ b/src/apps/wormhole/IncentivizedWormholeEscrow.sol
@@ -28,6 +28,7 @@ contract IncentivizedWormholeEscrow is IncentivizedMessageEscrow, WormholeVerifi
     ) internal override view returns(bytes32) {
         return keccak256(
             abi.encodePacked(
+                msg.sender,
                 bytes32(block.number),
                 chainId(), 
                 destinationIdentifier,

--- a/test/IncentivizedMessageEscrow/escrowMessage/EscrowMessage.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/EscrowMessage.t.sol
@@ -31,7 +31,7 @@ contract EscrowInformationTest is TestCommon {
         IncentiveDescription storage incentive = _INCENTIVE;
 
         vm.expectEmit();
-        emit BountyPlaced(bytes32(0x2dfdcf3ed929fb394f4f06ccf6d75629926d36dc4409186a42a5904a2f80d74d), incentive);
+        emit BountyPlaced(bytes32(0xb9ca07b4390ffb7693876d025f356c92a2a0502b46c9cd4ad0aecb195774ec98), incentive);
 
         escrow.submitMessage{value: _getTotalIncentive(_INCENTIVE)}(
             bytes32(uint256(0x123123) + uint256(2**255)),

--- a/test/IncentivizedMessageEscrow/escrowMessage/MessageIdentifier.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/MessageIdentifier.t.sol
@@ -16,7 +16,7 @@ contract MessageIdentifierTest is TestCommon {
             incentive
         );
 
-        assertEq(messageIdentifier, bytes32(0x7d115fc12d69b0838b2ba4a0a17beac33c5aa489e50d17565642b46e724a1b1f));
+        assertEq(messageIdentifier, bytes32(0x63d67e3fce2ed64674223d39595772649b279109e9bffd287446258b536459ac));
     }
 
     function test_unique_identifier_block_11() public {
@@ -29,7 +29,7 @@ contract MessageIdentifierTest is TestCommon {
             incentive
         );
 
-        assertEq(messageIdentifier, bytes32(0xeaa2656c806ede225c7826a7d7f26fbc0f3ba4c918a54ed06a04842f76fef24b));
+        assertEq(messageIdentifier, bytes32(0xff33b82153b4b666a3b395852e06879d8be2aab78d77e93307ba3879e1cf7042));
     }
 
     // Even with the same message, the identifier should be different between blocks.
@@ -75,7 +75,7 @@ contract MessageIdentifierTest is TestCommon {
             incentive
         );
 
-        assertEq(messageIdentifier1, bytes32(0x7d9ecc6ce9343b45ddf5643fdc24b97e1dafea3c3859295759ad4b292ad08cf1));
-        assertEq(messageIdentifier2, bytes32(0x373c6daaaee9fb27298c4ae298c8922b86a3cc41c9869d102aeb5ca37da7cf4a));
+        assertEq(messageIdentifier1, bytes32(0x0336e79dacdcf5c72d112c6a1dcc16484993043f84feb08300a9c78ee317ff09));
+        assertEq(messageIdentifier2, bytes32(0x27a6da8297249099dc55dcdcd0de9b3114fdded9901a151414e2a1eea034f9db));
     }
 }


### PR DESCRIPTION
Protect the system against DoS attacks by adding msg.sender to the application. This requires applications to think about DoS but significantly simplifies the attack surface. `msg.origin` is not used because it is less exact for some chains.

https://github.com/hats-finance/Catalyst-Exchange-0x3026c1ea29bf1280f99b41934b2cb65d053c9db4/issues/46