### PR TITLE
Set solidity 0.8.22 as minimum

### DIFF
--- a/src/IncentivizedMessageEscrow.sol
+++ b/src/IncentivizedMessageEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { Address } from "openzeppelin/utils/Address.sol";
 

--- a/src/MessagePayload.sol
+++ b/src/MessagePayload.sol
@@ -1,6 +1,6 @@
 //SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 // IncentivizedMessageEscrow Payload***********************************************************************************************
 //

--- a/src/apps/mock/IncentivizedMockEscrow.sol
+++ b/src/apps/mock/IncentivizedMockEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IncentivizedMessageEscrow } from "../../IncentivizedMessageEscrow.sol";
 

--- a/src/apps/mock/OnRecvIncentivizedMockEscrow.sol
+++ b/src/apps/mock/OnRecvIncentivizedMockEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IncentivizedMessageEscrow } from "../../IncentivizedMessageEscrow.sol";
 import { MockOnRecvAMB } from "../../../test/mocks/MockOnRecvAMB.sol";

--- a/src/apps/polymer/IncentivizedPolymerEscrow.sol
+++ b/src/apps/polymer/IncentivizedPolymerEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import {IncentivizedMessageEscrow} from "../../IncentivizedMessageEscrow.sol";
 import "../../MessagePayload.sol";

--- a/src/apps/wormhole/IncentivizedWormholeEscrow.sol
+++ b/src/apps/wormhole/IncentivizedWormholeEscrow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IncentivizedMessageEscrow } from "../../IncentivizedMessageEscrow.sol";
 

--- a/src/utils/Bytes65.sol
+++ b/src/utils/Bytes65.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 contract Bytes65 {
     error InvalidBytes65Address();

--- a/test/IncentivizedMessageEscrow/TimeoutMessage.t.sol
+++ b/test/IncentivizedMessageEscrow/TimeoutMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { Bytes65 } from "../../src/utils/Bytes65.sol";

--- a/test/IncentivizedMessageEscrow/escrowMessage/Deadline.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/Deadline.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/escrowMessage/EscrowMessage.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/EscrowMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/escrowMessage/MessageIdentifier.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/MessageIdentifier.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/escrowMessage/NoRemoteImplementation.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/NoRemoteImplementation.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/escrowMessage/WrongGasPayment.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/WrongGasPayment.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/escrowMessage/refundGasTo.t.sol
+++ b/test/IncentivizedMessageEscrow/escrowMessage/refundGasTo.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/feature/SendMessagePayment.t.sol
+++ b/test/IncentivizedMessageEscrow/feature/SendMessagePayment.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/increaseBounty/IncreaseBounty.t.sol
+++ b/test/IncentivizedMessageEscrow/increaseBounty/IncreaseBounty.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/GasSpendControl.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/GasSpendControl.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/NoReceive.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/NoReceive.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/Reentry.ack.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/Reentry.ack.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/Reentry.call.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/Reentry.call.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/RequirePaymentFromRelayer.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/RequirePaymentFromRelayer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/ReturnBomb.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/ReturnBomb.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/TargetDeltaZero.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/TargetDeltaZero.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/TimeOverflow.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/TimeOverflow.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/_handleAck.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/_handleAck.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/_handleCall.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/_handleCall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/_handleTimeout.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/_handleTimeout.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { Bytes65 } from "../../../src/utils/Bytes65.sol";

--- a/test/IncentivizedMessageEscrow/processMessage/_verifyTimeout.t.sol
+++ b/test/IncentivizedMessageEscrow/processMessage/_verifyTimeout.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { Bytes65 } from "../../../src/utils/Bytes65.sol";

--- a/test/IncentivizedMessageEscrow/reemitAck/AnyAckExploit.t.sol
+++ b/test/IncentivizedMessageEscrow/reemitAck/AnyAckExploit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { IncentivizedMockEscrow } from "../../../src/apps/mock/IncentivizedMockEscrow.sol";

--- a/test/IncentivizedMessageEscrow/reemitAck/ReemitAckMessage.t.sol
+++ b/test/IncentivizedMessageEscrow/reemitAck/ReemitAckMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../../TestCommon.t.sol";

--- a/test/IncentivizedMessageEscrow/setRemoteImplementation.t.sol
+++ b/test/IncentivizedMessageEscrow/setRemoteImplementation.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestCommon } from "../TestCommon.t.sol";

--- a/test/OnRecvIncentivizedMockEscrow/TestOnRecvCommon.t.sol
+++ b/test/OnRecvIncentivizedMockEscrow/TestOnRecvCommon.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { OnRecvIncentivizedMockEscrow } from "../../src/apps/mock/OnRecvIncentivizedMockEscrow.sol";

--- a/test/OnRecvIncentivizedMockEscrow/processMessage/_handleAck.t.sol
+++ b/test/OnRecvIncentivizedMockEscrow/processMessage/_handleAck.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestOnRecvCommon } from "../TestOnRecvCommon.t.sol";

--- a/test/OnRecvIncentivizedMockEscrow/processMessage/_handleCall.t.sol
+++ b/test/OnRecvIncentivizedMockEscrow/processMessage/_handleCall.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestOnRecvCommon } from "../TestOnRecvCommon.t.sol";

--- a/test/OnRecvIncentivizedMockEscrow/processMessage/_handleTimeout.t.sol
+++ b/test/OnRecvIncentivizedMockEscrow/processMessage/_handleTimeout.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestOnRecvCommon } from "../TestOnRecvCommon.t.sol";

--- a/test/OnRecvIncentivizedMockEscrow/processMessage/processMessage.t.sol
+++ b/test/OnRecvIncentivizedMockEscrow/processMessage/processMessage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestOnRecvCommon } from "../TestOnRecvCommon.t.sol";

--- a/test/OnRecvIncentivizedMockEscrow/processMessage/recoverAck.t.sol
+++ b/test/OnRecvIncentivizedMockEscrow/processMessage/recoverAck.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import { TestOnRecvCommon } from "../TestOnRecvCommon.t.sol";

--- a/test/TestCommon.t.sol
+++ b/test/TestCommon.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import "forge-std/Test.sol";
 import "../src/apps/mock/IncentivizedMockEscrow.sol";

--- a/test/mocks/BadContract.sol
+++ b/test/mocks/BadContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IIncentivizedMessageEscrow } from "../../src/interfaces/IIncentivizedMessageEscrow.sol";
 import { ICrossChainReceiver } from "../../src/interfaces/ICrossChainReceiver.sol";

--- a/test/mocks/MockApplication.sol
+++ b/test/mocks/MockApplication.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IIncentivizedMessageEscrow } from "../../src/interfaces/IIncentivizedMessageEscrow.sol";
 import { ICrossChainReceiver } from "../../src/interfaces/ICrossChainReceiver.sol";

--- a/test/mocks/MockOnRecvAMB.sol
+++ b/test/mocks/MockOnRecvAMB.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 /**
  * @title Mock On Recv AMB implementation

--- a/test/mocks/MockSpendGas.sol
+++ b/test/mocks/MockSpendGas.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IIncentivizedMessageEscrow } from "../../src/interfaces/IIncentivizedMessageEscrow.sol";
 import { ICrossChainReceiver } from "../../src/interfaces/ICrossChainReceiver.sol";

--- a/test/mocks/ReturnBomber.sol
+++ b/test/mocks/ReturnBomber.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.22;
 
 import { IIncentivizedMessageEscrow } from "../../src/interfaces/IIncentivizedMessageEscrow.sol";
 import { ICrossChainReceiver } from "../../src/interfaces/ICrossChainReceiver.sol";


### PR DESCRIPTION
Solidity 0.8.22 introduces a fix to address reproducability which is needed for create2 deployments.